### PR TITLE
Adds GA CI tests

### DIFF
--- a/.github/workflows/client-cli.yml
+++ b/.github/workflows/client-cli.yml
@@ -1,0 +1,94 @@
+name: QuantaDB CLI Client CI
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'cli-client/**'
+      - '.github/workflows/client-cli.yml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'cli-client/**'
+      - '.github/workflows/client-cli.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test CLI Client
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+
+    - name: Cache cargo registry
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          cli-client/target
+        key: ${{ runner.os }}-cargo-cli-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-cli-
+
+    - name: Check formatting
+      run: cd cli-client && cargo fmt -- --check
+
+    - name: Run clippy
+      run: cd cli-client && cargo clippy -- -D warnings
+
+    - name: Build CLI client
+      run: cd cli-client && cargo build --verbose
+
+    - name: Run tests
+      run: cd cli-client && cargo test --verbose
+
+    - name: Test CLI help
+      run: |
+        cd cli-client
+        timeout 5s cargo run -- --help || true
+        echo "CLI help command completed successfully"
+
+  build-matrix:
+    name: Build CLI on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo registry
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          cli-client/target
+        key: ${{ runner.os }}-cargo-cli-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-cli-
+
+    - name: Build CLI client
+      run: cd cli-client && cargo build --release --verbose
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: quanta-cli-${{ matrix.os }}
+        path: cli-client/target/release/quanta-cli*
+        retention-days: 7

--- a/.github/workflows/quantadb-server.yml
+++ b/.github/workflows/quantadb-server.yml
@@ -1,0 +1,94 @@
+name: QuantaDB Server CI
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'server/**'
+      - '.github/workflows/quantadb-server.yml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'server/**'
+      - '.github/workflows/quantadb-server.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test QuantaDB Server
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+
+    - name: Cache cargo registry
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          server/target
+        key: ${{ runner.os }}-cargo-server-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-server-
+
+    - name: Check formatting
+      run: cd server && cargo fmt -- --check
+
+    - name: Run clippy
+      run: cd server && cargo clippy -- -D warnings
+
+    - name: Build server
+      run: cd server && cargo build --verbose
+
+    - name: Run tests
+      run: cd server && cargo test --verbose
+
+    - name: Test server startup
+      run: |
+        cd server
+        timeout 10s cargo run -- --help || true
+        echo "Server help command completed successfully"
+
+  build-matrix:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo registry
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          server/target
+        key: ${{ runner.os }}-cargo-server-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-server-
+
+    - name: Build server
+      run: cd server && cargo build --release --verbose
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: quantadb-server-${{ matrix.os }}
+        path: server/target/release/quanta-server*
+        retention-days: 7


### PR DESCRIPTION
This pull request introduces dedicated GitHub Actions CI workflows for both the QuantaDB CLI client and the server. These workflows automate linting, formatting checks, building, testing, and artifact uploads for their respective components, ensuring consistent quality and cross-platform builds.

**New GitHub Actions CI workflows:**

*QuantaDB CLI Client:*
- Adds `.github/workflows/client-cli.yml` to automate formatting checks, linting with Clippy, building, testing, and uploading release artifacts for the CLI client across Ubuntu, Windows, and macOS.

*QuantaDB Server:*
- Adds `.github/workflows/quantadb-server.yml` to perform similar automation for the server, including formatting, linting, building, testing, and artifact uploads on multiple platforms.