### PR TITLE
Develop

### DIFF
--- a/.github/workflows/client-cli.yml
+++ b/.github/workflows/client-cli.yml
@@ -3,92 +3,17 @@ name: QuantaDB CLI Client CI
 on:
   push:
     branches: [ "main" ]
-    paths:
-      - 'cli-client/**'
-      - '.github/workflows/client-cli.yml'
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'cli-client/**'
-      - '.github/workflows/client-cli.yml'
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
-    name: Test CLI Client
+  build:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
-
-    - name: Cache cargo registry
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          cli-client/target
-        key: ${{ runner.os }}-cargo-cli-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-cli-
-
-    - name: Check formatting
-      run: cd cli-client && cargo fmt -- --check
-
-    - name: Run clippy
-      run: cd cli-client && cargo clippy -- -D warnings
-
+    - uses: actions/checkout@v4
     - name: Build CLI client
       run: cd cli-client && cargo build --verbose
-
-    - name: Run tests
-      run: cd cli-client && cargo test --verbose
-
-    - name: Test CLI help
-      run: |
-        cd cli-client
-        timeout 5s cargo run -- --help || true
-        echo "CLI help command completed successfully"
-
-  build-matrix:
-    name: Build CLI on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-
-    - name: Cache cargo registry
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          cli-client/target
-        key: ${{ runner.os }}-cargo-cli-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-cli-
-
-    - name: Build CLI client
-      run: cd cli-client && cargo build --release --verbose
-
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: quanta-cli-${{ matrix.os }}
-        path: cli-client/target/release/quanta-cli*
-        retention-days: 7

--- a/.github/workflows/quantadb-server.yml
+++ b/.github/workflows/quantadb-server.yml
@@ -3,92 +3,17 @@ name: QuantaDB Server CI
 on:
   push:
     branches: [ "main" ]
-    paths:
-      - 'server/**'
-      - '.github/workflows/quantadb-server.yml'
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'server/**'
-      - '.github/workflows/quantadb-server.yml'
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
-    name: Test QuantaDB Server
+  build:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
-
-    - name: Cache cargo registry
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          server/target
-        key: ${{ runner.os }}-cargo-server-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-server-
-
-    - name: Check formatting
-      run: cd server && cargo fmt -- --check
-
-    - name: Run clippy
-      run: cd server && cargo clippy -- -D warnings
-
+    - uses: actions/checkout@v4
     - name: Build server
       run: cd server && cargo build --verbose
-
-    - name: Run tests
-      run: cd server && cargo test --verbose
-
-    - name: Test server startup
-      run: |
-        cd server
-        timeout 10s cargo run -- --help || true
-        echo "Server help command completed successfully"
-
-  build-matrix:
-    name: Build on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-
-    - name: Cache cargo registry
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          server/target
-        key: ${{ runner.os }}-cargo-server-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-server-
-
-    - name: Build server
-      run: cd server && cargo build --release --verbose
-
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: quantadb-server-${{ matrix.os }}
-        path: server/target/release/quanta-server*
-        retention-days: 7


### PR DESCRIPTION
This pull request significantly simplifies the GitHub Actions CI workflows for both the CLI client and the server. The workflows have been refactored to focus solely on building the respective components on Ubuntu, removing all test, lint, formatting, and multi-OS build steps. This change streamlines CI but also reduces coverage and validation.

**Workflow simplification:**

* The `.github/workflows/client-cli.yml` and `.github/workflows/quantadb-server.yml` workflows have been refactored to only run a single build job on `ubuntu-latest`, removing all test, lint (clippy), formatting (rustfmt), and multi-platform build matrix steps. Only the build step remains for each. [[1]](diffhunk://#diff-426bcb0d5ec42697bdf783f419c18bc598563c79fb5ebf799c7e705f8ec12169L6-L94) [[2]](diffhunk://#diff-ecb9b4bebbafa57917ee2b578f412785dd79d0a55d1ca233bc58e6cba79dfd35L6-L94)

**Trigger configuration changes:**

* The workflow triggers have been simplified by removing the `paths` filters, so workflows will now run on all pushes and pull requests to `main`, regardless of which files are changed. [[1]](diffhunk://#diff-426bcb0d5ec42697bdf783f419c18bc598563c79fb5ebf799c7e705f8ec12169L6-L94) [[2]](diffhunk://#diff-ecb9b4bebbafa57917ee2b578f412785dd79d0a55d1ca233bc58e6cba79dfd35L6-L94)